### PR TITLE
Upgrade Webpack to v4

### DIFF
--- a/config/webpack/webpack-base.js
+++ b/config/webpack/webpack-base.js
@@ -5,6 +5,7 @@ const outputPath = path.join(rootPath, 'dist');
 const bannerPlugin = require('./plugins/banner');
 
 module.exports = {
+  mode: 'development',
   context,
   entry: {
     cornerstoneWebImageLoader: './index.js',

--- a/config/webpack/webpack-prod.js
+++ b/config/webpack/webpack-prod.js
@@ -1,15 +1,19 @@
-const webpack = require('webpack');
 const merge = require('./merge');
 const baseConfig = require('./webpack-base');
+const UglifyJSPlugin = require('uglifyjs-webpack-plugin');
+
 const prodConfig = {
   output: {
     filename: '[name].min.js'
   },
-  plugins: [
-    new webpack.optimize.UglifyJsPlugin({
-      sourceMap: true
-    })
-  ]
+  mode: "production",
+  optimization: {
+    minimizer: [
+      new UglifyJSPlugin({
+        sourceMap: true
+      })
+    ]
+  }
 };
 
 module.exports = merge(baseConfig, prodConfig);

--- a/package.json
+++ b/package.json
@@ -53,8 +53,8 @@
     "cornerstone-core": "^2.0.0",
     "coveralls": "^3.0.0",
     "docdash": "^0.4.0",
-    "eslint": "^4.9.0",
-    "eslint-loader": "^1.9.0",
+    "eslint": "^4.19.1",
+    "eslint-loader": "^2.0.0",
     "eslint-plugin-import": "^2.8.0",
     "istanbul-instrumenter-loader": "^3.0.0",
     "jsdoc": "^3.5.5",
@@ -64,12 +64,14 @@
     "karma-firefox-launcher": "^1.0.1",
     "karma-mocha": "^1.3.0",
     "karma-phantomjs-launcher": "^1.0.4",
-    "karma-webpack": "^2.0.5",
+    "karma-webpack": "^3.0.0",
     "lodash": "4.17.4",
     "mocha": "^4.0.1",
     "opn-cli": "^3.1.0",
     "shx": "^0.2.2",
     "uglify-js": "^3.1.5",
-    "webpack": "^3.8.1"
+    "uglifyjs-webpack-plugin": "^1.2.4",
+    "webpack": "^4.5.0",
+    "webpack-cli": "^2.0.13"
   }
 }


### PR DESCRIPTION
## Changes 
- Upgrade webpack to v4
- `npm start` and `npm test` are working fine.
- Example tested

## Notes
After this PR, `npm install`  is needed in the next use. 
 