### PR TITLE
feat: Add support for loading images with blob urls

### DIFF
--- a/src/registerLoaders.js
+++ b/src/registerLoaders.js
@@ -4,4 +4,5 @@ export default function (cornerstone) {
   // Register the http and https prefixes so we can use standard web urls directly
   cornerstone.registerImageLoader('http', loadImage);
   cornerstone.registerImageLoader('https', loadImage);
+  cornerstone.registerImageLoader('blob', loadImage);
 }


### PR DESCRIPTION
Register `blob` as scheme instead of `blob:http` or `blob:https` because
cornerstone-core splits on `:` and uses the first part as the scheme. So,
if provided a url `blob:https://github.com/test-id` it will consider `blob`
as the scheme instead of `blob:https`.

Closes https://github.com/cornerstonejs/cornerstoneWebImageLoader/issues/13